### PR TITLE
Bed temp error

### DIFF
--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -316,7 +316,8 @@ class Command:
                     continue
                 builder.add_field(title='Extruder Temp (%s)' % heater, text=temperatures[heater]['actual'], inline=True)
 
-            builder.add_field(title='Bed Temp', text=temperatures['bed']['actual'], inline=True)
+            if temperatures['bed']['actual']:
+                builder.add_field(title='Bed Temp', text=temperatures['bed']['actual'], inline=True)
 
             printing = self.plugin.get_printer().is_printing()
             builder.add_field(title='Printing', text='Yes' if printing else 'No', inline=True)


### PR DESCRIPTION
If there is no heated bed it shows text error

Made the script ignore bed temp if bed temp call returns false or '$None'

Error:
![bed error](https://user-images.githubusercontent.com/45603366/56874650-01d8ae80-6a01-11e9-97fe-abc611523bfb.PNG)

Fixed:
![bed fixed](https://user-images.githubusercontent.com/45603366/56874651-01d8ae80-6a01-11e9-9a2a-cebc443bc111.PNG)
