### PR TITLE
Prefix ambiguity

### DIFF
--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -42,25 +42,27 @@ class Command:
             command_plugin.setup(self, plugin)
 
     def parse_command(self, string, user=None):
+        prefix_char = self.plugin.get_settings().get(["prefix"])
         parts = re.split('\s+', string)
 
         prefix_len = len(self.plugin.get_settings().get(["prefix"]))
-        command_string = parts[0][prefix_len:]
-        command = self.command_dict.get(command_string)
-        if command is None:
-            if parts[0][0] == self.plugin.get_settings().get(["prefix"]) or \
-                    parts[0].lower() == "help":
-                return self.help()
-            return None, None
-
-        if user and not self.check_perms(command_string, user):
-            return None, error_embed(author=self.plugin.get_printer_name(),
-                                     title="Permission Denied")
-
-        if command.get('params'):
-            return command['cmd'](parts)
-        else:
-            return command['cmd']()
+        if prefix_char == parts[0][:1]:
+            command_string = parts[0][prefix_len:]
+            command = self.command_dict.get(command_string)
+            if command is None:
+                if parts[0][0] == self.plugin.get_settings().get(["prefix"]) or \
+                        parts[0].lower() == "help":
+                    return self.help()
+                return None, None
+    
+            if user and not self.check_perms(command_string, user):
+                return None, error_embed(author=self.plugin.get_printer_name(),
+                                         title="Permission Denied")
+    
+            if command.get('params'):
+                return command['cmd'](parts)
+            else:
+                return command['cmd']()
 
     def timelapse(self):
 


### PR DESCRIPTION
Bot would detect any leading character as a prefix.

Added 'If' check to see if first character matched prefix in settings.

Both bots respond to the Kossel prefix:

![prefix error](https://user-images.githubusercontent.com/45603366/56875450-a8737e00-6a06-11e9-86a0-c3838e110493.PNG)

Kossel ignores FrankenCube prefix (FrankenCube unpatched for testing)

![prefix fixed](https://user-images.githubusercontent.com/45603366/56875451-a8737e00-6a06-11e9-952f-4773a4fe6f24.PNG)

