### PR TITLE
Prefix ambiguity

### DIFF
--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -46,7 +46,7 @@ class Command:
         parts = re.split('\s+', string)
 
         prefix_len = len(self.plugin.get_settings().get(["prefix"]))
-        if prefix_char == parts[0][0] or user="Dummy":
+        if prefix_char == parts[0][0] or user == "Dummy":
             command_string = parts[0][prefix_len:]
             command = self.command_dict.get(command_string)
             if command is None:

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -42,25 +42,27 @@ class Command:
             command_plugin.setup(self, plugin)
 
     def parse_command(self, string, user=None):
+        prefix_char = self.plugin.get_settings().get(["prefix"])
         parts = re.split('\s+', string)
 
         prefix_len = len(self.plugin.get_settings().get(["prefix"]))
-        command_string = parts[0][prefix_len:]
-        command = self.command_dict.get(command_string)
-        if command is None:
-            if parts[0][0] == self.plugin.get_settings().get(["prefix"]) or \
-                    parts[0].lower() == "help":
-                return self.help()
-            return None, None
+        if prefix_char == parts[0][0] or user="Dummy":
+            command_string = parts[0][prefix_len:]
+            command = self.command_dict.get(command_string)
+            if command is None:
+                if parts[0][0] == self.plugin.get_settings().get(["prefix"]) or \
+                        parts[0].lower() == "help":
+                    return self.help()
+                return None, None
 
-        if user and not self.check_perms(command_string, user):
-            return None, error_embed(author=self.plugin.get_printer_name(),
-                                     title="Permission Denied")
+            if user and not self.check_perms(command_string, user):
+                return None, error_embed(author=self.plugin.get_printer_name(),
+                                         title="Permission Denied")
 
-        if command.get('params'):
-            return command['cmd'](parts)
-        else:
-            return command['cmd']()
+            if command.get('params'):
+                return command['cmd'](parts)
+            else:
+                return command['cmd']()
 
     def timelapse(self):
 


### PR DESCRIPTION
parse_command did not check for valid prefix, would respond to any character (sstatus $status /status) ignoring the settings.

Also added sanity check for the Continuous Integration tests, if command is run as 'user == "Dummy"' it ignores the prefix check.