### PR TITLE
Fix command prefix reversion.

### DIFF
--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -53,8 +53,10 @@ class Command:
         parts = re.split(r'\s+', string)
 
         command_string = "help"
-        if len(parts[0]) > len(prefix_str) and prefix_str == parts[0][:prefix_len]:
-            command_string = parts[0][prefix_len:]
+        if len(parts[0]) < prefix_len or prefix_str != parts[0][:prefix_len]:
+            return None, None
+
+        command_string = parts[0][prefix_len:]
 
         command = self.command_dict.get(command_string, {'cmd': self.help})
 

--- a/unittests/test_command.py
+++ b/unittests/test_command.py
@@ -115,7 +115,7 @@ class TestCommand(DiscordRemoteTestCase):
 
         self.command.command_dict['help'] = {'cmd': self.command.help, 'description': "Mock help."}
 
-        for command in ['help', '/asdf', 'asdf', "", "/"]:
+        for command in ['/asdf', "/", "/help", "/?"]:
             self.command.check_perms.reset_mock()
             self.command.help.reset_mock()
             snapshots, embeds = self.command.parse_command(command, user="Dummy")
@@ -123,6 +123,15 @@ class TestCommand(DiscordRemoteTestCase):
             self.assertIsNone(embeds)
             self.command.help.assert_called_once()
             self.command.check_perms.assert_called_once()
+
+        for command in ['asdf / fdsa', 'help', 'whatever']:
+            self.command.check_perms.reset_mock()
+            self.command.help.reset_mock()
+            snapshots, embeds = self.command.parse_command(command, user="Dummy")
+            self.assertIsNone(snapshots)
+            self.assertIsNone(embeds)
+            self.command.help.assert_not_called()
+            self.command.check_perms.assert_not_called()
 
         self.command.check_perms.reset_mock()
         self.command.check_perms.return_value = False


### PR DESCRIPTION
Hi cameroncros,

I love how easy it was to get started with your plugin, but soon after I installed it I noticed that the bot responded to every message in the channel, regardless of whether or not it contained a command. [This commit](https://github.com/cameroncros/OctoPrint-DiscordRemote/commit/206a842f398addb25dcae4e65d1b30c654db54c1#diff-efc848f6e4f3d95c93e0703d800605dcR55) leads me to believe that this behavior is unintentional.

Here's my proposed fix. I tested it with `test.sh`.

Thanks :)