### PR TITLE
Add Hostname Masking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ config.yaml
 .coverage
 htmlcov/
 .tox/
+
+.vscode

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -198,7 +198,8 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
             'show_local_ip': True,
             'show_external_ip': True,
             'use_hostname': False,
-            'hostname': "3d.example.com",
+            'hostname': "YOUR.HOST.NAME",
+            'use_hostname_only': False,
             'events': self.events,
             'permissions': self.permissions,
             'allow_scripts': False,
@@ -221,6 +222,7 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
                            ["show_external_ip"],
                            ["use_hostname"],
                            ["hostname"],
+                           ["use_hostname_only"],
                            ['script_before'],
                            ['script_after'],
                            ['allowed_gcode']])
@@ -378,6 +380,12 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
         data['timeremaining'] = self.get_print_time_remaining()
         data['timespent'] = self.get_print_time_spent()
 
+        # Convert IP -> Hostname if desired
+        if self.get_settings().get(['use_hostname'], merged=True):
+            data['externaddr'] = self.get_settings().get(['hostname'], merged=True)
+            if self.get_settings().get(['use_hostname_only'], merged=True):
+                data['ipaddr'] = self.get_settings().get(['hostname'], merged=True)
+
         # Special case for progress eventID : we check for progress and steps
         if event_id == 'printing_progress':
             # Skip if just started
@@ -426,9 +434,7 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
 
     def get_external_ip_address(self):
         if self.get_settings().get(['show_external_ip'], merged=True):
-            if self.get_settings().get(['use_hostname'], merged=True):
-                return self.get_settings().get(['hostname'])
-            else return ipgetter.myip()
+            ipgetter.myip()
         else:
             return "External IP disabled"
 

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -197,6 +197,8 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
             'prefix': "/",
             'show_local_ip': True,
             'show_external_ip': True,
+            'use_hostname': False,
+            'hostname': "3d.example.com",
             'events': self.events,
             'permissions': self.permissions,
             'allow_scripts': False,
@@ -217,6 +219,8 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
                            ['prefix'],
                            ["show_local_ip"],
                            ["show_external_ip"],
+                           ["use_hostname"],
+                           ["hostname"],
                            ['script_before'],
                            ['script_after'],
                            ['allowed_gcode']])
@@ -422,7 +426,9 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
 
     def get_external_ip_address(self):
         if self.get_settings().get(['show_external_ip'], merged=True):
-            return ipgetter.myip()
+            if self.get_settings().get(['use_hostname'], merged=True):
+                return self.get_settings().get(['hostname'])
+            else return ipgetter.myip()
         else:
             return "External IP disabled"
 

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -434,7 +434,7 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
 
     def get_external_ip_address(self):
         if self.get_settings().get(['show_external_ip'], merged=True):
-            ipgetter.myip()
+            return ipgetter.myip()
         else:
             return "External IP disabled"
 

--- a/octoprint_discordremote/templates/discordremote_settings.jinja2
+++ b/octoprint_discordremote/templates/discordremote_settings.jinja2
@@ -120,6 +120,22 @@
                        data-bind="checked: settings.plugins.discordremote.show_external_ip"/>
             </div>
         </div>
+        <div class="control-group">
+            <label class="control-label">{{ _('Use Hostname instead of External IP') }}</label>
+            <div class="controls">
+                <input type="checkbox" class="input-block-level"
+                       data-bind="checked: settings.plugins.discordremote.use_hostname"/>
+            </div>
+        </div>
+        <div class="control-group">
+            <label class="control-label">{{ _('Hostname') }}</label>
+            <div style="clear:both">
+                <small>{{ _("Hostname to use instead of External IP.") }}</small>
+            </div>
+            <div class="controls">
+                <input type="text" class="input-block-level" data-bind="value: settings.plugins.discordremote.hostname"/>
+            </div>
+        </div>
     </form>
 
     <h3>{{ _('Messages settings') }}</h3>

--- a/octoprint_discordremote/templates/discordremote_settings.jinja2
+++ b/octoprint_discordremote/templates/discordremote_settings.jinja2
@@ -121,7 +121,7 @@
             </div>
         </div>
         <div class="control-group">
-            <label class="control-label">{{ _('Use Hostname instead of External IP') }}</label>
+            <label class="control-label">{{ _('Use Hostname') }}</label>
             <div class="controls">
                 <input type="checkbox" class="input-block-level"
                        data-bind="checked: settings.plugins.discordremote.use_hostname"/>
@@ -129,11 +129,15 @@
         </div>
         <div class="control-group">
             <label class="control-label">{{ _('Hostname') }}</label>
-            <div style="clear:both">
-                <small>{{ _("Hostname to use instead of External IP.") }}</small>
-            </div>
             <div class="controls">
                 <input type="text" class="input-block-level" data-bind="value: settings.plugins.discordremote.hostname"/>
+            </div>
+        </div>
+        <div class="control-group">
+            <label class="control-label">{{ _('Only use Hostname') }}</label>
+            <div class="controls">
+                <input type="checkbox" class="input-block-level"
+                       data-bind="checked: settings.plugins.discordremote.use_hostname_only"/>
             </div>
         </div>
     </form>


### PR DESCRIPTION
Simple changes to allow for a user configurable hostname to be shown instead of IP addresses, useful for public discord channels or utilizing reverse proxies. I've got a few more things I would like to implement, but made the PR so we can get the basic functionality out there. This should satisfy the request in #88.