### PR TITLE
Update Discord domain from discordapp.com to discord.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Here you can customize every message handled by DiscordRemote.
 ## Message format
 
 Messages are regular Discord messages, which means you can use :
-- `**markdown**` format (see [Discord Documentation](https://support.discordapp.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-))
+- `**markdown**` format (see [Discord Documentation](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-))
 - `:emoji:` shortcuts to display emojis
 - `@mentions` to notify someone
 

--- a/octoprint_discordremote/discord.py
+++ b/octoprint_discordremote/discord.py
@@ -39,7 +39,7 @@ class Discord:
     def __init__(self):
         self.channel_id = None  # enable dev mode on discord, right-click on the channel, copy ID
         self.bot_token = None  # get from the bot page. must be a bot, not a discord app
-        self.gateway_url = "https://discordapp.com/api/gateway"
+        self.gateway_url = "https://discord.com/api/gateway"
         self.postURL = None  # URL to post messages to, as the bot
         self.heartbeat_sent = 0
         self.heartbeat_interval = None
@@ -86,7 +86,7 @@ class Discord:
             self.shutdown_discord()
             return
 
-        self.postURL = "https://discordapp.com/api/channels/{}/messages".format(self.channel_id)
+        self.postURL = "https://discord.com/api/channels/{}/messages".format(self.channel_id)
         self.headers = {"Authorization": "Bot {}".format(self.bot_token),
                         "User-Agent": "myBotThing (http://some.url, v0.1)"}
 


### PR DESCRIPTION
Discord has moved from discordapp.com to discord.com - API with old domain will work till 7th of November 2020.

Reference https://discord.com/developers/docs/reference // Base URL