### PR TITLE
Added ability to send .zip files

### DIFF
--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -36,6 +36,17 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
                           octoprint.plugin.TemplatePlugin,
                           octoprint.plugin.ProgressPlugin,
                           octoprint.plugin.SimpleApiPlugin):
+  
+    @property
+    def allowed(self):
+        list = 'zip'
+        for i in range(0,100):
+            list += ','
+            list += str(i).zfill(3)
+        return list
+
+    def get_extension_tree(self, *args, **kwargs):
+        return dict(machinecode=dict(discordremote=self.allowed.split(",")))
 
     def __init__(self):
         self.discord = None
@@ -669,5 +680,6 @@ def __plugin_load__():
 
     global __plugin_hooks__
     __plugin_hooks__ = {
-        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
+        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
+        "octoprint.filemanager.extension_tree": __plugin_implementation__.get_extension_tree
     }

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -36,17 +36,13 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
                           octoprint.plugin.TemplatePlugin,
                           octoprint.plugin.ProgressPlugin,
                           octoprint.plugin.SimpleApiPlugin):
-  
-    @property
-    def allowed(self):
-        list = 'zip'
-        for i in range(0,100):
-            list += ','
-            list += str(i).zfill(3)
-        return list
 
+    #extend Octoprint's allowed file types by .zip, .zip.001, .zip.002, ...)
     def get_extension_tree(self, *args, **kwargs):
-        return dict(machinecode=dict(discordremote=self.allowed.split(",")))
+        allowed_list = [zip]
+        for i in range(0, 100):
+            allowed_list.append(str(i).zfill(3))
+        return dict(machinecode=dict(discordremote=allowed_list))
 
     def __init__(self):
         self.discord = None

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -39,7 +39,7 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
 
     #extend Octoprint's allowed file types by .zip, .zip.001, .zip.002, ...)
     def get_extension_tree(self, *args, **kwargs):
-        allowed_list = [zip]
+        allowed_list = ['zip']
         for i in range(0, 100):
             allowed_list.append(str(i).zfill(3))
         return dict(machinecode=dict(discordremote=allowed_list))

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -420,34 +420,40 @@ class Command:
             unzippable = upload_file_path
 
         else:
-            return None, error_embed(author=self.plugin.get_printer_name(), title="Not a valid Zip file.", description='try "%sunzip [filename].zip or %sunzip [filename].zip.001 for multi-volume files."' % self.plugin.get_settings().get(
-                                         ["prefix"]))
+            return None, error_embed(author=self.plugin.get_printer_name(), title="Not a valid Zip file.", description='try "%sunzip [filename].zip or %sunzip [filename].zip.001 for multi-volume files."' % (self.plugin.get_settings().get(
+                                         ["prefix"]), self.plugin.get_settings().get(
+                                         ["prefix"])))
 
         if unzippable == None:
             return None, error_embed(author=self.plugin.get_printer_name(), title="File %s not found." % file_name)
 
 
-        with zipfile.ZipFile(unzippable) as zip:
+        try:
+            with zipfile.ZipFile(unzippable) as zip:
 
-            fileOK = zip.testzip()
+                fileOK = zip.testzip()
 
-            if fileOK is not None:
-                return None, error_embed(author=self.plugin.get_printer_name(), title="Bad zip file.", description='In case of multi-volume files, one could be missing.')
+                if fileOK is not None:
+                    return None, error_embed(author=self.plugin.get_printer_name(), title="Bad zip file.", description='In case of multi-volume files, one could be missing.')
 
-            availablefiles = zip.namelist()
-            filestounpack = []
-            for f in availablefiles:
-                if f.endswith('.gcode'):
-                    filestounpack.append(f)
+                availablefiles = zip.namelist()
+                filestounpack = []
+                for f in availablefiles:
+                    if f.endswith('.gcode'):
+                        filestounpack.append(f)
 
-            path = unzippable.rpartition('/')[0] + '/'
+                path = unzippable.rpartition('/')[0] + '/'
 
-            for f in filestounpack:
-                with open(path + f, 'wb') as file:
-                    with zip.open(f) as source:
-                        file.write(source.read())
-                        
-            self.plugin.get_file_manager().remove_file('local', unzippable.rpartition('/')[2])
+                for f in filestounpack:
+                    with open(path + f, 'wb') as file:
+                        with zip.open(f) as source:
+                            file.write(source.read())
+
+                self.plugin.get_file_manager().remove_file('local', unzippable.rpartition('/')[2])
+
+        except:
+            return None, error_embed(author=self.plugin.get_printer_name(), title="Bad zip file.",
+                                 description='In case of multi-volume files, one could be missing.')
 
         return None, success_embed(author=self.plugin.get_printer_name(), title='File(s) unzipped. ', description=str(filestounpack))
 

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -7,6 +7,7 @@ import humanfriendly
 import re
 import time
 import requests
+import zipfile
 
 from octoprint.printer import InvalidFileLocation, InvalidFileType
 
@@ -25,6 +26,8 @@ class Command:
         self.command_dict['print'] = {'cmd': self.start_print, 'params': "{filename}", 'description': "Print a file."}
         self.command_dict['files'] = {'cmd': self.list_files,
                                       'description': "List all files and respective download links."}
+        self.command_dict['unzip'] = {'cmd': self.unzip, 'params': "{filename}",
+                                      'description': "Unzip .zip files and .zip.001, .zip.002,... files"}
         self.command_dict['abort'] = {'cmd': self.cancel_print, 'description': "Abort a print."}
         self.command_dict['snapshot'] = {'cmd': self.snapshot, 'description': "Take a snapshot with the camera."}
         self.command_dict['status'] = {'cmd': self.status, 'description': "Get the current printer status."}
@@ -368,6 +371,85 @@ class Command:
         return None, success_embed(author=self.plugin.get_printer_name(),
                                    title='File Received',
                                    description=filename)
+    
+    
+    def unzip(self, params):
+        if len(params) != 2:
+            return None, error_embed(author=self.plugin.get_printer_name(),
+                                     title='Wrong number of arguments',
+                                     description='try "%sunzip [filename]"' % self.plugin.get_settings().get(
+                                         ["prefix"]))
+
+        file_name = params[1]
+
+        flat_filelist = self.get_flat_file_list()
+
+        unzippable = None
+
+        if file_name.endswith('.zip'):
+            for file in flat_filelist:
+                if file_name.upper() in file.get('path').upper():
+                    unzippable = self.plugin.get_file_manager().path_on_disk(file.get('location'), file_name)
+                    break
+
+        elif file_name.endswith('.zip.001'):
+            files = []
+            truncated = file_name[:-3]
+            current = 1
+            found = True
+            while found:
+                found = False
+                fn = truncated + str(current).zfill(3)
+                for file in flat_filelist:
+                    if fn.upper() in file.get('path').upper():
+                        files.append(fn)
+                        current += 1
+                        found = True
+                        break
+            upload_file_path = self.plugin.get_file_manager().path_on_disk('local', truncated[:-1])
+            if self.plugin.get_file_manager().file_exists('local', upload_file_path.rpartition('/')[2]):
+                self.plugin.get_file_manager().remove_file('local', upload_file_path.rpartition('/')[2])
+            with open(upload_file_path, 'ab') as combined:
+                for f in files:
+                    path = self.plugin.get_file_manager().path_on_disk('local', f)
+                    with open(path, 'rb') as temp:
+                        combined.write(temp.read())
+                    self.plugin.get_file_manager().remove_file('local', f.rpartition('/')[2])
+
+
+            unzippable = upload_file_path
+
+        else:
+            return None, error_embed(author=self.plugin.get_printer_name(), title="Not a valid Zip file.", description='try "%sunzip [filename].zip or %sunzip [filename].zip.001 for multi-volume files."' % self.plugin.get_settings().get(
+                                         ["prefix"]))
+
+        if unzippable == None:
+            return None, error_embed(author=self.plugin.get_printer_name(), title="File %s not found." % file_name)
+
+
+        with zipfile.ZipFile(unzippable) as zip:
+
+            fileOK = zip.testzip()
+
+            if fileOK is not None:
+                return None, error_embed(author=self.plugin.get_printer_name(), title="Bad zip file.", description='In case of multi-volume files, one could be missing.')
+
+            availablefiles = zip.namelist()
+            filestounpack = []
+            for f in availablefiles:
+                if f.endswith('.gcode'):
+                    filestounpack.append(f)
+
+            path = unzippable.rpartition('/')[0] + '/'
+
+            for f in filestounpack:
+                with open(path + f, 'wb') as file:
+                    with zip.open(f) as source:
+                        file.write(source.read())
+
+        return None, success_embed(author=self.plugin.get_printer_name(), title='File(s) unzipped. ', description=str(filestounpack))
+
+    
 
     def mute(self):
         self.plugin.mute()

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -446,6 +446,8 @@ class Command:
                 with open(path + f, 'wb') as file:
                     with zip.open(f) as source:
                         file.write(source.read())
+                        
+            self.plugin.get_file_manager().remove_file('local', unzippable.rpartition('/')[2])
 
         return None, success_embed(author=self.plugin.get_printer_name(), title='File(s) unzipped. ', description=str(filestounpack))
 

--- a/unittests/test_command.py
+++ b/unittests/test_command.py
@@ -2,6 +2,8 @@ import humanfriendly
 import mock
 import os
 
+from zipfile import ZipFile
+
 from octoprint.printer import InvalidFileType, InvalidFileLocation
 
 from octoprint_discordremote import Command, DiscordRemotePlugin
@@ -39,6 +41,17 @@ flatten_file_list = [
      'analysis': {'printingArea': {'maxZ': None, 'maxX': None, 'maxY': None, 'minX': None, 'minY': None, 'minZ': None},
                   'dimensions': {'width': 0.0, 'depth': 0.0, 'height': 0.0},
                   'filament': {'tool0': {'volume': 0.0, 'length': 0.0}}}, 'display': u'test.gcode'}]
+
+zip_flat_file_list = [
+    {'hash': 'e2337a4310c454a0198718425330e62fcbe4329e', 'location': 'local', 'name': u'testzip.zip',
+     'date': 1525822021, 'path': u'/testzip.zip', 'size': 6530},
+    {'hash': 'e2337a4310c454a0198718425330e62fcbe4329e', 'location': 'local', 'name': u'testzipMV.zip.001', 'date': 1525822021,
+     'path': u'/testzipMV.zip.001', 'size': 6530},
+    {'hash': 'e2337a4310c454a0198718425330e62fcbe4329e', 'location': 'local', 'name': u'testzipMV.zip.002', 'date': 1525822021,
+     'path': u'/testzipMV.zip.002', 'size': 6530},
+    {'hash': 'e2337a4310c454a0198718425330e62fcbe4329e', 'location': 'local', 'name': u'testzipMV.zip.003', 'date': 1525822021,
+     'path': u'/testzipMV.zip.003', 'size': 6530}
+]
 
 class TestCommand(DiscordRemoteTestCase):
 
@@ -610,3 +623,101 @@ class TestCommand(DiscordRemoteTestCase):
         snapshots, embeds = self.command.gettimelapse(["/gettimelapse", "test.gcode"])
         self.assertTrue(snapshots)
         self.assertTrue(embeds)
+
+    def test_unzip(self):
+
+        #prepare a working  dummy zip
+        with ZipFile('./testzip.zip', 'w') as zipf:
+            zipf.writestr('test.gcode', "Proper GCODE file!")
+            zipf.writestr('test.txt', "Don't extract that!")
+            zipf.close()
+
+        #create a multi-volume dummy zip, too
+        #code adapted, taken from Jeronimo's answer in https://stackoverflow.com/questions/52193680/split-a-zip-archive-into-multiple-chunks
+        outfile = './testzipMV.zip'
+        packet_size = int(100)  # bytes
+
+        with open('./testzip.zip', "rb") as output:
+            filecount = 1
+            while True:
+                data = output.read(packet_size)
+                if not data:
+                    break  # we're done
+                with open("{}.{:03}".format(outfile, filecount), "wb") as packet:
+                    packet.write(data)
+                filecount += 1
+
+        #reroute any call to Octoprint's local folder to project local folder
+        def path_sideeff(*args, **kwargs):
+            if args[0] is 'local':
+                return os.path.join('./', args[1])
+            return None
+
+        self.plugin.get_file_manager().path_on_disk = mock.Mock()
+        self.plugin.get_file_manager().path_on_disk.side_effect = path_sideeff
+
+        self.command.get_flat_file_list = mock.Mock()
+        self.command.get_flat_file_list.return_value = []
+
+    # CASE 1: File doesn't exist
+        snapshot, embeds = self.command.unzip(["/unzip", "testzip.zip"])
+        self.assertIsNone(snapshot)
+        self._validate_simple_embed(embeds, COLOR_ERROR, title="File testzip.zip not found.")
+
+
+    # CASE 2: File exists but is not a zip file
+        self.plugin.get_settings().get = mock.Mock()
+        self.plugin.get_settings().get.return_value = ''
+
+        snapshot, embeds = self.command.unzip(["/unzip", "testzip.nope"])
+        self.assertIsNone(snapshot)
+        self._validate_simple_embed(embeds,
+                                    COLOR_ERROR,
+                                    title="Not a valid Zip file.")
+
+        self.command.get_flat_file_list.return_value = zip_flat_file_list
+
+    # CASE 3: File is a working zip file
+        snapshot, embeds = self.command.unzip(["/unzip", "testzip.zip"])
+        self.assertIsNone(snapshot)
+        self._validate_simple_embed(embeds,
+                                    COLOR_SUCCESS,
+                                    title="File(s) unzipped. ")
+
+        #make sure it didn't extract the unwanted .txt in the zip file, only the gcode file
+        self.assertTrue(os.path.isfile('./test.gcode'))
+        self.assertFalse(os.path.isfile('./test.txt'))
+
+        with open('./test.gcode') as f:
+            self.assertEqual("Proper GCODE file!", f.read())
+
+        os.remove('./test.gcode')
+        os.remove('./testzip.zip')
+
+
+    # CASE 4: File is a working multi-volume zip file
+        snapshot, embeds = self.command.unzip(["/unzip", "testzipMV.zip.001"])
+        self.assertIsNone(snapshot)
+        self._validate_simple_embed(embeds,
+                                    COLOR_SUCCESS,
+                                    title="File(s) unzipped. ")
+        #no need to test for unwanted extracted files, code is the same as for single-volume zips
+        os.remove('./test.gcode')
+        os.remove('./testzipMV.zip')
+
+
+    # CASE 5: File is a multi-volume zip file, but it's missing volumes
+        os.remove('./testzipMV.zip.002')
+        self.command.get_flat_file_list.return_value = [zip_flat_file_list[0], zip_flat_file_list[2]]
+
+        snapshot, embeds = self.command.unzip(["/unzip", "testzipMV.zip.001"])
+        self.assertIsNone(snapshot)
+        self._validate_simple_embed(embeds,
+                                    COLOR_ERROR,
+                                    title="Bad zip file.")
+
+        os.remove('./testzipMV.zip')
+        os.remove('./testzipMV.zip.001')
+        os.remove('./testzipMV.zip.003')
+
+

--- a/unittests/test_command.py
+++ b/unittests/test_command.py
@@ -647,14 +647,22 @@ class TestCommand(DiscordRemoteTestCase):
                     packet.write(data)
                 filecount += 1
 
-        #reroute any call to Octoprint's local folder to project local folder
+        #reroute calls to Octoprint's local folder to project local folder
         def path_sideeff(*args, **kwargs):
-            if args[0] is 'local':
+            if args[0] == 'local':
                 return os.path.join('./', args[1])
+            return None
+
+        def file_exists_sideeff(*args, **kwargs):
+            if args[0] == 'local':
+                return os.path.isfile(os.path.join('./', args[1]))
             return None
 
         self.plugin.get_file_manager().path_on_disk = mock.Mock()
         self.plugin.get_file_manager().path_on_disk.side_effect = path_sideeff
+
+        self.plugin.get_file_manager().file_exists = mock.Mock()
+        self.plugin.get_file_manager().file_exists.side_effect = file_exists_sideeff
 
         self.command.get_flat_file_list = mock.Mock()
         self.command.get_flat_file_list.return_value = []


### PR DESCRIPTION
I have added the function /unzip with which the user can send zipped files (both .zip and multi-volume .zip.001, zip.002, etc files) to the Discord bot. Only gcode files are extracted from the zip, after extraction the zip files are deleted and the gcode file is available for printing as usual.

By using zipped files it is possible to circumvent Discord's 8MB upload limit. The function allows for up to 99 multi-volume zips which can be 8MB each, enabling users to upload huge .gcode files.

How to use:

Case A - single-volume zip:
Call /unzip filename.zip

Case B - multi-volume zip:
Call /unzip filename.zip.001
The function will automatically search for the rest of the multi-volume.

If there are multiple gcode files in a zip, the function will extract them all.

! Make sure the Discord bot has accepted all of your files before calling /unzip !

