### PR TITLE
Added auto-unzipping

### DIFF
--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -223,7 +223,8 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
             'allow_scripts': False,
             'script_before': '',
             'script_after': '',
-            'allowed_gcode': ''
+            'allowed_gcode': '',
+            'auto_unzip': False
         }
 
     # Restricts some paths to some roles only
@@ -245,7 +246,8 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
                            ["use_hostname_only"],
                            ['script_before'],
                            ['script_after'],
-                           ['allowed_gcode']])
+                           ['allowed_gcode'],
+                           ['auto_unzip']])
 
     # AssetPlugin mixin
     def get_assets(self):

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -514,7 +514,7 @@ class Command:
             #unzip
             if autounzip:
                 return True, success_embed(author=self.plugin.get_printer_name(),
-                                           title='File Received, unzipping...',
+                                           title='File Received, starting to unzip....',
                                            description=filename)
 
             # inform the user that they can unzip the file themselves
@@ -626,7 +626,7 @@ class Command:
 
             else:
                 return True, success_embed(author=self.plugin.get_printer_name(),
-                                           title='All Files Received, unzipping...',
+                                           title='All Files Received, starting to unzip....',
                                            description=string_availablefiles)
 
         return False, success_embed(author=self.plugin.get_printer_name(),

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -17,12 +17,6 @@ from octoprint_discordremote.command_plugins import plugin_list
 from octoprint_discordremote.embedbuilder import EmbedBuilder, success_embed, error_embed, info_embed, upload_file
 
 
-#Constants
-ZIP_HEADER_READ_START = 18
-ZIP_HEADER_READ_BLOCK = 4
-
-
-
 class Command:
     def __init__(self, plugin):
         assert plugin
@@ -544,6 +538,11 @@ class Command:
                 if available_files_sizes[i] < smallest_filesize:
                     differing_found = True
                     last_index = int(available_files[i][-3:])
+                    break
+
+                elif available_files_sizes[i] > smallest_filesize:
+                    differing_found = True
+                    last_index = int(available_files[0][-3:])
                     break
 
 

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -491,7 +491,7 @@ class Command:
         return None, success_embed(author=self.plugin.get_printer_name(), title='File(s) unzipped. ', description=filelist_string)
 
     #check if received file is eligible for unzipping
-    def judge_zip_completion(self, filename):
+    def judge_is_unzippable(self, filename):
 
         autounzip = self.plugin.get_settings().get(['auto_unzip'])
         truncated = filename[:-4]
@@ -583,13 +583,13 @@ class Command:
 
             #we don't have the last file yet, can't find out how many volumes
             if differing_found is not True:
-                return False, success_embed(author=self.plugin.get_printer_name(),
+                return False, info_embed(author=self.plugin.get_printer_name(),
                                             title='%s of ??? Files Received' % (str(len(available_files))),
                                             description=string_availablefiles)
 
             #we have the first and last file, can't unzip but we know how many volumes there are now
             elif len(available_files) is not last_index:
-                return False, success_embed(author=self.plugin.get_printer_name(),
+                return False, info_embed(author=self.plugin.get_printer_name(),
                                             title='%s of %s Files Received' % (str(len(available_files)), str(last_index)),
                                             description=string_availablefiles)
 

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -553,19 +553,23 @@ class Command:
             #sort the filenames nicely so missing files can be easily identified
             #for multiple files in a row, don't display all of them
             available_files.sort(key=lambda x: int(x[-3:]))
-            blocks_availablefiles = []
-            current_block = [available_files[0]]
 
-            previous_index = 1
-            for i in range(1, len(available_files)):
-                file_number = int(available_files[i][-3:])
-                if file_number is not previous_index + 1:
-                    blocks_availablefiles.append(current_block)
-                    current_block = []
-                    previous_index = i
+            blocks_availablefiles = []
+            current_block = []
+            prev_index = int(available_files[0][-3:]) - 1
+            for i in range(0, len(available_files)):
+                curr_index = int(available_files[i][-3:])
+                if curr_index is prev_index + 1:
+                    current_block.append(available_files[i])
                 else:
-                    previous_index += 1
-                current_block.append(available_files[i])
+                    blocks_availablefiles.append(current_block)
+                    current_block = [available_files[i]]
+
+                prev_index = curr_index
+            blocks_availablefiles.append(current_block)
+
+
+
 
             string_availablefiles = ''
 

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -392,7 +392,7 @@ class Command:
 
     def download_file(self, filename, url, user):
         if user and not self.check_perms('upload', user):
-            return None, error_embed(author=self.plugin.get_printer_name(),
+            return False, error_embed(author=self.plugin.get_printer_name(),
                                      title="Permission Denied")
         upload_file_path = self.plugin.get_file_manager().path_on_disk('local', filename)
 
@@ -401,7 +401,7 @@ class Command:
             for chunk in r.iter_content(chunk_size=1024):
                 if chunk:  # filter out keep-alive new chunks
                     f.write(chunk)
-        return None, success_embed(author=self.plugin.get_printer_name(),
+        return True, success_embed(author=self.plugin.get_printer_name(),
                                    title='File Received',
                                    description=filename)
 

--- a/octoprint_discordremote/discord.py
+++ b/octoprint_discordremote/discord.py
@@ -288,7 +288,7 @@ class Discord:
 
                 self.command.download_file(filename, url, user)
                 #check if file is eligible for unzipping
-                ready_to_unpack, embeds = self.command.judge_zip_completion(filename)
+                ready_to_unpack, embeds = self.command.judge_is_unzippable(filename)
                 self.send(embeds=embeds)
 
                 if ready_to_unpack is True:

--- a/octoprint_discordremote/discord.py
+++ b/octoprint_discordremote/discord.py
@@ -285,8 +285,16 @@ class Discord:
             for upload in data['attachments']:
                 filename = upload['filename']
                 url = upload['url']
-                snapshots, embeds = self.command.download_file(filename, url, user)
+
+                self.command.download_file(filename, url, user)
+                #check if file is eligible for unzipping
+                ready_to_unpack, embeds = self.command.judge_zip_completion(filename)
                 self.send(embeds=embeds)
+
+                if ready_to_unpack is True:
+                    snapshots, embeds2 = self.command.unzip(['local', filename])
+                    self.send(embeds=embeds2)
+
 
         if 'content' in data and len(data['content']) > 0:
             snapshots, embeds = self.command.parse_command(data['content'], user)

--- a/octoprint_discordremote/discord.py
+++ b/octoprint_discordremote/discord.py
@@ -286,7 +286,10 @@ class Discord:
                 filename = upload['filename']
                 url = upload['url']
 
-                self.command.download_file(filename, url, user)
+                has_permission, embeds = self.command.download_file(filename, url, user)
+                if not has_permission:
+                    self.send(embeds=embeds)
+                    return
                 #check if file is eligible for unzipping
                 ready_to_unpack, embeds = self.command.judge_is_unzippable(filename)
                 self.send(embeds=embeds)

--- a/octoprint_discordremote/templates/discordremote_settings.jinja2
+++ b/octoprint_discordremote/templates/discordremote_settings.jinja2
@@ -56,6 +56,17 @@
             <small>{{ _("Time between each presence cycle update, in seconds. The default is 10. May require a restart to apply.") }}
             </small>
         </div>
+
+        <div class="control-group">
+            <label class="control-label">{{ _('Enable Auto-Unzipping') }}</label>
+            <div class="controls">
+                <input type="checkbox" class="" data-bind="checked: settings.plugins.discordremote.auto_unzip"/>
+            </div>
+        </div>
+        <div style="clear:both">
+            <small>{{ _("With auto-unzipping enabled, sent .zip and .zip.001, .zip.002, ... files will have their GCODE files extracted automatically.") }}
+            </small>
+        </div>
         
         <div style="clear:both">
             <small>{{ _("If you modify these settings, a test message will be sent to the Discord channel.") }}</small>

--- a/unittests/test_command.py
+++ b/unittests/test_command.py
@@ -458,7 +458,7 @@ class TestCommand(DiscordRemoteTestCase):
 
         # Upload, no user
         snapshot, embeds = self.command.download_file("filename", "http://mock.url", None)
-        self.assertIsNone(snapshot)
+        self.assertTrue(snapshot)
         self._validate_simple_embed(embeds,
                                     COLOR_SUCCESS,
                                     title="File Received")
@@ -478,7 +478,7 @@ class TestCommand(DiscordRemoteTestCase):
         self.command.check_perms.return_value = True
 
         snapshot, embeds = self.command.download_file("filename", "http://mock.url", "1234")
-        self.assertIsNone(snapshot)
+        self.assertTrue(snapshot)
         self._validate_simple_embed(embeds,
                                     COLOR_SUCCESS,
                                     title="File Received")
@@ -495,7 +495,7 @@ class TestCommand(DiscordRemoteTestCase):
         self.command.check_perms.return_value = False
 
         snapshot, embeds = self.command.download_file("filename", "http://mock.url", "1234")
-        self.assertIsNone(snapshot)
+        self.assertFalse(snapshot)
         self._validate_simple_embed(embeds,
                                     COLOR_ERROR,
                                     title="Permission Denied")

--- a/unittests/test_command.py
+++ b/unittests/test_command.py
@@ -780,7 +780,7 @@ class TestCommand(DiscordRemoteTestCase):
 
         payload, embeds = self.command.judge_is_unzippable("test.zip")
         self.assertTrue(payload)
-        self._validate_simple_embed(embeds, COLOR_SUCCESS, title="File Received, unzipping...")
+        self._validate_simple_embed(embeds, COLOR_SUCCESS, title="File Received, starting to unzip....")
 
         # CASE 2: File is a .zip but we're not allowed to auto-unzip
         self.plugin.get_settings().get.return_value = False
@@ -803,7 +803,7 @@ class TestCommand(DiscordRemoteTestCase):
 
         payload, embeds = self.command.judge_is_unzippable("testzipMV.zip.002")
         self.assertTrue(payload)
-        self._validate_simple_embed(embeds, COLOR_SUCCESS, title="All Files Received, unzipping...")
+        self._validate_simple_embed(embeds, COLOR_SUCCESS, title="All Files Received, starting to unzip....")
 
         # CASE 5: File is a multi-volume .zip.001, ... file, one volume present
 


### PR DESCRIPTION
By default, auto-unzipping is turned off, it can be turned on in the plugin's settings.

Auto-unzipping detects multi-volume files (and their total count if possible) and regular zip files, and unzips them if possible.

During sending single-volume files, the user is told:
- that a file has been received
-If auto-unzipping is enabled, the user will then get a message of a successful unzip (or an error, depending on whether the zip file is corrupted or not).
-If auto-unzipping is disabled, the user will get a message that the file has been received and that he can use the unzip command to extract the files himself.

During receiving multi-volume files, the user is told:
- how many files have been uploaded, and their names in a neatly structured list
- how many files there should be in total if that number is known
-If auto-unzipping is enabled and all files are there, the user will get a message that his files have been unzipped.
-If auto-unzipping is disabled, the user will get a message informing him that he can unzip the files himself using the unzip command.

As a side effect, it is now possible to call the unzip command using any of the received files, not just the one ending in ".zip.001".


The unit test tests for the following cases:

1: File is a .zip and we're allowed to auto-unzip
2: File is a .zip but we're not allowed to auto-unzip
3: File is not a .zip file
4: File is a multi-volume .zip.001, ... file, all volumes present
5: File is a multi-volume .zip.001, ... file, one volume present
6: File is a multi-volume .zip.001, ... file, two volumes present, last one not included
7: File is a multi-volume .zip.001, ... file, two volumes present, last one included
8: File is a multi-volume .zip.001, ... file, all volumes present but we're not allowed to auto-unzip
