### PR TITLE
Add support for showing absolute ETA

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See the following link for instructions on how to setup a Discord bot:
 
 - The Channel ID is the ID of the TEXT channel within the Discord Server that the bot is communicating with, not the Discord Server.
 - When following (https://github.com/Chikachi/DiscordIntegration/wiki/How-to-get-a-token-and-channel-ID-for-Discord), STOP after "Get the channel ID of the Discord text channel" section. Everything else is not needed on that page.
-- OAuth2 permissions are not necessary.  
+- OAuth2 permissions are not necessary.
 - If you reinstall your Octoprint system, you only need the bot token and channel ID to get it back up and running.
 
 ## API
@@ -121,7 +121,7 @@ The access settings allow specific commands to be limited to specific users.
 * In the users section, put a comma-separated list of user IDs.
   * The user ID needs to be the numerical form, which is a number like: 165259232034275409
   * In a text channel, find a message sent by you (or send one) and then right-click your name over that message and click "Copy ID"
-  * Or, join a voice channel, and then right-click your name in the sidebar, and click "Copy ID" 
+  * Or, join a voice channel, and then right-click your name in the sidebar, and click "Copy ID"
   * The text user ID (like "MyUser" or "MyUser#1234") will result in "Permission Denied" responses to commands.
 * A '*' in either section can be used to match all commands/users.
 
@@ -154,6 +154,7 @@ Some events also support variables, here is a basic list :
 - `{externaddr}` : the external IP address of the OctoPrint server
 - `{timeremaining}` : the time remaining for the print ('Unknown' if the print is not running)
 - `{timespent}` : the time spent so far on the print
+- `{eta}` : the date+time which is `{timeremaining}` into the future
 
 **Printing process : started event** :
 - `{name}` : file's name that's being printed

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ License : MIT
 
 [Stwend](https://github.com/Stwend) for adding split zip support, to get around the 8mb discord limit.
 
+[Mary](https://github.com/kijk2869) for preventing the bot replying to other bots, and avoiding downloading non-gcode/zip files.
+
 ## Changelog
 
 See [the release history](https://github.com/cameroncros/OctoPrint-DiscordRemote/releases) to get a quick summary of what's new in the latest versions.

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -396,6 +396,7 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
         data['externaddr'] = self.get_external_ip_address()
         data['timeremaining'] = self.get_print_time_remaining()
         data['timespent'] = self.get_print_time_spent()
+        data['eta'] = self.get_print_eta()
 
         # Special case for progress eventID : we check for progress and steps
         if event_id == 'printing_progress':
@@ -617,6 +618,17 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
         try:
             remaining_time_val = current_data['progress']['printTimeLeft']
             return humanfriendly.format_timespan(remaining_time_val, max_units=2)
+        except (KeyError, ValueError):
+            return 'Unknown'
+
+    def get_print_eta(self):
+        current_data = self._printer.get_current_data()
+        try:
+            remaining_time_val = current_data['progress']['printTimeLeft']
+            return (
+                (datetime.now() + timedelta(seconds=remaining_time_val))
+                .isoformat(' ', 'minutes')
+            )
         except (KeyError, ValueError):
             return 'Unknown'
 

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -330,13 +330,14 @@ class Command:
             printing = self.plugin.get_printer().is_printing()
             builder.add_field(title='Printing', text='Yes' if printing else 'No', inline=True)
             if printing:
-                builder.add_field(title='File', text=current_data['job']['file']['name'], inline=True)
+                builder.add_field(title='File', text=f"`{current_data['job']['file']['name']}`", inline=True)
                 completion = current_data['progress']['completion']
                 if completion:
                     builder.add_field(title='Progress', text='%d%%' % completion, inline=True)
 
                 builder.add_field(title='Time Spent', text=self.plugin.get_print_time_spent(), inline=True)
                 builder.add_field(title='Time Remaining', text=self.plugin.get_print_time_remaining(), inline=True)
+                builder.add_field(title='ETA', text=self.plugin.get_print_eta(), inline=True)
 
         try:
             cmd_response = subprocess.Popen(['vcgencmd', 'get_throttled'], stdout=subprocess.PIPE).communicate()

--- a/octoprint_discordremote/discord.py
+++ b/octoprint_discordremote/discord.py
@@ -357,7 +357,7 @@ class Discord:
         if self.status_callback:
             self.status_callback(connected="connected")
         if self.error_counter > 0:
-            self.error_counter -= 0
+            self.error_counter = 0
         self.heartbeat_sent = 0
         self.process_queue()
 


### PR DESCRIPTION
i.e. instead of the estimated amount of time remaining in the print, this is the datetime at which the print is estimated to finish.

Also, while I was at it, I put the status-embed's filename field inside backticks, so that filenames containing double underscores don't get mangled by Discord's Markdown interpretation.