### PR TITLE
Fixed presence

### DIFF
--- a/octoprint_discordremote/discordimpl.py
+++ b/octoprint_discordremote/discordimpl.py
@@ -113,11 +113,11 @@ class DiscordImpl:
         except Exception as e:
             self.logger.error("Failed with: %s" % e)
 
-    def update_presence(self, msg):
+    def update_presence(self, status, msg):
         try:
             if self.client.ws:
                 self.loop.create_task(
-                    self.client.change_presence(activity=discord.Activity(url='http://octoprint.url', name=msg)))
+                    self.client.change_presence(activity=discord.Activity(type=discord.ActivityType.watching, name=msg),status=discord.Status[status]))
         except:
             pass
 

--- a/octoprint_discordremote/presence.py
+++ b/octoprint_discordremote/presence.py
@@ -38,7 +38,7 @@ class Presence:
 
     def generate_status(self):
         if self.plugin.get_printer().is_operational():
-            if self.plugin.get_printer().is_printing() and not self.plugin.get_printer().is_ready():
+            if self.plugin.get_printer().is_printing():
                 job_name = self.plugin.get_printer().get_current_data()['job']['file']['name']
                 job_percent = self.plugin.get_printer().get_current_data()['progress']['completion']
                 return ["online", "{}% of {} complete".format(

--- a/octoprint_discordremote/presence.py
+++ b/octoprint_discordremote/presence.py
@@ -19,6 +19,7 @@ class Presence:
         self.discord: Optional['DiscordImpl'] = None
         self.presence_cycle_id: int = 0
         self.presence_thread: Optional[Thread] = None
+        self.last_status = None
 
     def configure_presence(self, plugin: 'DiscordRemotePlugin', discord: 'DiscordImpl'):
         self.plugin = plugin
@@ -30,33 +31,31 @@ class Presence:
             self.presence_thread = Thread(target=self.presence)
             self.presence_thread.start()
 
+    def update(self, status, msg):
+        if not status == self.last_status:
+            self.discord.update_presence(status, msg)
+            self.last_status = status
+
     def generate_status(self):
         if self.plugin.get_printer().is_operational():
-            if self.plugin.get_printer().is_printing():
+            if self.plugin.get_printer().is_printing() and not self.plugin.get_printer().is_ready():
                 job_name = self.plugin.get_printer().get_current_data()['job']['file']['name']
                 job_percent = self.plugin.get_printer().get_current_data()['progress']['completion']
-                return "Printing {} - {}%".format(job_name,
-                                                  humanfriendly.format_number(job_percent, num_decimals=2))
+                return ["online", "{}% of {} complete".format(
+                                                  humanfriendly.format_number(job_percent, num_decimals=2),
+                                                  job_name)]
             else:
-                return "Idle."
+                return ["idle", " and waiting"]
         else:
-            return "Not operational."
+            return ["offline", "for printer to come online"]
 
     def presence(self):
-        presence_cycle = {
-            0: "{}help".format(self.plugin.get_settings().get(["prefix"])),
-            1: self.generate_status()
-        }
         while not self.discord.shutdown_event.is_set():
             if self.plugin.get_settings().get(['presence']):
-                presence_cycle[1] = "{}".format(self.generate_status())
-                self.discord.update_presence(presence_cycle[self.presence_cycle_id % len(presence_cycle)])
-
-                self.presence_cycle_id += 1
-                if self.presence_cycle_id == len(presence_cycle):
-                    self.presence_cycle_id = 0
+                [status, presence] = self.generate_status()
+                self.update(status, presence)
             else:
-                self.discord.update_presence(None)
+                self.update("online", None)
 
             for i in range(int(self.plugin.get_settings().get(['presence_cycle_time']))):
                 if not self.discord.shutdown_event.is_set():


### PR DESCRIPTION
Presence wasn't working, so I changed the ActivityType to "Watching", updated the text a little bit, and it will set a "idle", "online", or "offline" whether the printer is idling, actively printing, or has an operational error, respectively.