### PR TITLE
Fixed Python Compatibility

### DIFF
--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -667,7 +667,7 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
 # ("OctoPrint-PluginSkeleton"), you may define that here. Same goes for the other metadata derived from setup.py that
 # can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "DiscordRemote"
-__plugin_pythoncompat__ = ">=2.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 
 
 def __plugin_load__():


### PR DESCRIPTION
Fixes issue #239

This fixes an important compatibility issue where Octoprint attempts to upgrade the plugin despite not having the required Python version. Based on [this](https://docs.octoprint.org/en/master/plugins/python3_migration.html#telling-octoprint-your-plugin-is-python-3-ready) page from the octoprint docs. 

Another fix must also be performed on the [octoprint plugin repository](https://github.com/OctoPrint/plugins.octoprint.org/blob/gh-pages/_plugins/discordremote.md) so that OctoPrint’s built-in Plugin Manager can work properly. 