### PR TITLE
Notify when specifc gcodes are sent to the printer (e.g. M600)

### DIFF
--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -144,6 +144,13 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
                 "with_snapshot": True,
                 "message": "Hello hello! If you see this message, it means that the settings are correct!"
             },
+            "gcode_sent": {
+                "name": "Printing process : Specific gcode sent",
+                "enabled": False,
+                "with_snapshot": True,
+                "message": "📢 {gcode} gcode sent!",
+                "gcodes": "M600"
+            },
         }
         self.permissions = {
             '1': {'users': '*', 'commands': ''},
@@ -318,6 +325,13 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
 
         return True
     
+    def parse_gcode_sent(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
+        if gcode:
+            gcodes = self._settings.get(["events", "gcode_sent", "gcodes"]).split(",")
+            if gcode in gcodes:
+                self.notify_event("gcode_sent", {"gcode": gcode})
+        return
+
     def on_print_progress(self, location, path, progress):
         # Avoid sending duplicate percentage progress messages
         if progress != self.last_progress_percent:
@@ -681,5 +695,6 @@ def __plugin_load__():
     global __plugin_hooks__
     __plugin_hooks__ = {
         "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
-        "octoprint.filemanager.extension_tree": __plugin_implementation__.get_extension_tree
+        "octoprint.filemanager.extension_tree": __plugin_implementation__.get_extension_tree,
+        "octoprint.comm.protocol.gcode.sent": __plugin_implementation__.parse_gcode_sent
     }

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -317,7 +317,7 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
             return self.notify_event("printing_done", payload)
 
         return True
-
+    
     def on_print_progress(self, location, path, progress):
         # Avoid sending duplicate percentage progress messages
         if progress != self.last_progress_percent:

--- a/octoprint_discordremote/templates/discordremote_settings.jinja2
+++ b/octoprint_discordremote/templates/discordremote_settings.jinja2
@@ -34,7 +34,7 @@
                 your local network. If left blank, this setting will fall back to the Pi's local IP.") }}
             </small>
         </div>
-        
+
         <div class="control-group">
             <label class="control-label">{{ _('Enable Presence') }}</label>
             <div class="controls">
@@ -44,7 +44,7 @@
         <div style="clear:both">
             <small>{{ _("Check this box to enable a rotating status message within Discord, showing the currently configured prefix and printer status. May require a restart to apply.") }}
             </small>
-        </div>   
+        </div>
 
         <div class="control-group">
             <label class="control-label">{{ _('Presence Cycle') }}</label>
@@ -56,7 +56,7 @@
             <small>{{ _("Time between each presence cycle update, in seconds. The default is 10. May require a restart to apply.") }}
             </small>
         </div>
-        
+
         <div style="clear:both">
             <small>{{ _("If you modify these settings, a test message will be sent to the Discord channel.") }}</small>
         </div>
@@ -188,6 +188,7 @@
                            data-bind="checked: $parent.settings.plugins.discordremote.events[$data].with_snapshot"/>
                 </div>
             </div>
+
             <!-- Special Case for Percentage reporting -->
             <div class="control-group" data-bind="if: $parent.settings.plugins.discordremote.events[$data].step">
                 <label class="control-label">{{ _("Notify every") }}</label>
@@ -208,6 +209,7 @@
                            data-bind="value: $parent.settings.plugins.discordremote.events[$data].timeout"/>s
                 </div>
             </div>
+
             <!-- Special Case for Periodic reporting -->
             <div class="control-group" data-bind="if: $parent.settings.plugins.discordremote.events[$data].period">
                 <label class="control-label">{{ _("Notify every") }}</label>
@@ -216,6 +218,7 @@
                            data-bind="value: $parent.settings.plugins.discordremote.events[$data].period"/>s
                 </div>
             </div>
+
         </div>
     </form>
     <h3>Scripts settings</h3>

--- a/octoprint_discordremote/templates/discordremote_settings.jinja2
+++ b/octoprint_discordremote/templates/discordremote_settings.jinja2
@@ -219,6 +219,16 @@
                 </div>
             </div>
 
+            <!-- Special Case for gcode reporting -->
+            <div class="control-group" data-bind="if: $parent.settings.plugins.discordremote.events[$data].gcodes">
+                <p>{{ _("A comma-seperated list of gcodes to monitor for (e.g M600,M620,M510).") }}
+                </p>
+                <label class="control-label">{{ _("List of gcodes (csv)") }}</label>
+                <div class="controls">
+                    <input type="text" class="input-block-level" data-bind="value: $parent.settings.plugins.discordremote.events[$data].gcodes"/>
+                </div>
+            </div>
+
         </div>
     </form>
     <h3>Scripts settings</h3>


### PR DESCRIPTION
This PR adds the ability to be notified when specific gcodes are sent to the printer.

A common use case for this is detecting when the M600 (filament change) gcode is sent. It's common for the printers to not clearly identify to octoprint they're waiting for human input (i.e. they don't report as being "paused").

This change supporst any arbitrary gcode detection, not just M600.

This feature (or support for M600 generally) been requested in the past, e.g. https://github.com/cameroncros/OctoPrint-DiscordRemote/issues/165 & https://github.com/cameroncros/OctoPrint-DiscordRemote/issues/65

**Setting page:**

![image](https://github.com/cameroncros/OctoPrint-DiscordRemote/assets/131580/510eaa6e-1471-4a39-841e-be3534a09ae4)

**Example discord message:**

![image](https://github.com/cameroncros/OctoPrint-DiscordRemote/assets/131580/3737d36e-9dc7-4dbd-86db-145027e6b8ba)
