### PR TITLE
Octoprint 2.0.0 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,16 @@ or manually using this URL:
 There are currently 2 API's available for interacting with the bot.
 These can be used by sending a POST request to `[octoprint_url]/api/plugin/discordremote`, with JSON in the body of the request.
 
+All requests must be authenticated. Pass your OctoPrint API key via the `X-Api-Key` header:
+
+    X-Api-Key: YOUR_API_KEY_HERE
+
+See the [OctoPrint authorization documentation](https://docs.octoprint.org/en/dev/api/general.html#authorization) for details on how to obtain and use API keys.
+
 ### Send command
+
+**Required permission:** `PLUGIN_DISCORDREMOTE_EXECUTE` (granted to Admins and Users by default)
+
 This API lets you send a command as if you typed it in discord.
 The response will be sent to discord.
 The JSON format is:
@@ -82,6 +91,9 @@ The JSON format is:
     }
 
 ### Send message
+
+**Required permission:** `PLUGIN_DISCORDREMOTE_NOTIFY` (granted to Admins and Users by default)
+
 This API lets you send a message directly to discord.
 The JSON format is:
 

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -14,7 +14,6 @@ from typing import Optional
 
 import humanfriendly
 import octoprint.plugin
-import octoprint.settings
 import requests
 from PIL import Image
 from flask import make_response

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -7,24 +7,25 @@ import socket
 import subprocess
 import time
 from base64 import b64decode
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from io import BytesIO
-from threading import Thread, Event
+from threading import Event, Thread
 from typing import Optional
 
 import humanfriendly
 import octoprint.plugin
 import requests
-from PIL import Image
 from flask import make_response
-from requests import ConnectionError
 from octoprint.access import ADMIN_GROUP, USER_GROUP
 from octoprint.access.permissions import Permissions
+from PIL import Image
+from requests import ConnectionError
 
 from octoprint_discordremote.command import Command
+
 from .discordlink import DiscordLink
 from .libs import ipgetter
-from .proto.messages_pb2 import EmbedContent, ProtoFile, Response, Presence
+from .proto.messages_pb2 import EmbedContent, Presence, ProtoFile, Response
 
 
 class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -17,8 +17,9 @@ import octoprint.plugin
 import requests
 from PIL import Image
 from flask import make_response
-from octoprint.server import user_permission
 from requests import ConnectionError
+from octoprint.access import ADMIN_GROUP, USER_GROUP
+from octoprint.access.permissions import Permissions
 
 from octoprint_discordremote.command import Command
 from .discordlink import DiscordLink
@@ -278,6 +279,27 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
     def is_template_autoescaped(self):
         return True
 
+    # Custom permissions hook
+    def get_additional_permissions(self):
+        return [
+            {
+                "key": "EXECUTE",
+                "name": "Execute command",
+                "description": "Allows executing Discord bot commands.",
+                "roles": ["execute"],
+                "dangerous": False,
+                "default_groups": [ADMIN_GROUP, USER_GROUP],
+            },
+            {
+                "key": "MESSAGE",
+                "name": "Send messages",
+                "description": "Allows sending messages to Discord via the API.",
+                "roles": ["message"],
+                "dangerous": False,
+                "default_groups": [ADMIN_GROUP, USER_GROUP],
+            },
+        ]
+
     # Softwareupdate hook
     def get_update_information(self):
         # Define the configuration for your plugin to use with the Software Update
@@ -372,13 +394,14 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
         )
 
     def on_api_command(self, comm, data):
-        if not user_permission.can():
-            return make_response("Insufficient rights", 403)
-
         if comm == 'executeCommand':
+            if not Permissions.PLUGIN_DISCORDREMOTE_EXECUTE.can():
+                return make_response("Insufficient rights", 403)
             return self.execute_command(data)
 
         if comm == 'sendMessage':
+            if not Permissions.PLUGIN_DISCORDREMOTE_MESSAGE.can():
+                return make_response("Insufficient rights", 403)
             return self.unpack_message(data)
 
     def execute_command(self, data):
@@ -747,6 +770,7 @@ def __plugin_load__():
 
     global __plugin_hooks__
     __plugin_hooks__ = {
+        "octoprint.access.permissions": __plugin_implementation__.get_additional_permissions,
         "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
         "octoprint.filemanager.extension_tree": __plugin_implementation__.get_extension_tree,
         "octoprint.comm.protocol.gcode.sent": __plugin_implementation__.parse_gcode_sent

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -276,6 +276,9 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
             dict(type="settings", custom_bindings=False)
         ]
 
+    def is_template_autoescaped(self):
+        return True
+
     # Softwareupdate hook
     def get_update_information(self):
         # Define the configuration for your plugin to use with the Software Update

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -363,6 +363,9 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
         self.configure_discord()
 
     # SimpleApiPlugin mixin
+    def is_api_protected(self):
+        return True
+
     def get_api_commands(self):
         return dict(
             executeCommand=['args'],

--- a/octoprint_discordremote/__init__.py
+++ b/octoprint_discordremote/__init__.py
@@ -525,7 +525,8 @@ class DiscordRemotePlugin(octoprint.plugin.EventHandlerPlugin,
             out = err
         finally:
             self._logger.info("{}:{} > Output: '{}'".format(event_name, which, out))
-            return out
+
+        return out
 
     def send_message(self, event_id, message, with_snapshot=False):
         # exec "before" script if any

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -6,7 +6,6 @@ import urllib
 import humanfriendly
 import re
 import time
-import requests
 import zipfile
 import subprocess
 

--- a/octoprint_discordremote/command.py
+++ b/octoprint_discordremote/command.py
@@ -2,24 +2,28 @@ from __future__ import unicode_literals
 
 import collections
 import os
-import urllib
-import humanfriendly
 import re
-import time
-import zipfile
 import subprocess
-
-from octoprint.printer import InvalidFileLocation, InvalidFileType
-
+import time
+import urllib
+import zipfile
 from typing import TYPE_CHECKING, List, Optional
 
-from .proto.messages_pb2 import EmbedContent, TextField, ProtoFile, Response
+import humanfriendly
+from octoprint.printer import InvalidFileLocation, InvalidFileType
+
+from .proto.messages_pb2 import EmbedContent, ProtoFile, Response, TextField
 
 if TYPE_CHECKING:
     from octoprint_discordremote import DiscordRemotePlugin
 
 from octoprint_discordremote.command_plugins import plugin_list
-from octoprint_discordremote.responsebuilder import success_embed, error_embed, info_embed, COLOR_INFO
+from octoprint_discordremote.responsebuilder import (
+    COLOR_INFO,
+    error_embed,
+    info_embed,
+    success_embed,
+)
 
 
 class Command:

--- a/octoprint_discordremote/connectiontest.py
+++ b/octoprint_discordremote/connectiontest.py
@@ -4,10 +4,16 @@ from typing import Tuple
 
 try:
     from .genericforeversocket import GenericForeverSocket
-    from .proto.messages_pb2 import Response, Settings, Request, EmbedContent, ProtoFile
+    from .proto.messages_pb2 import EmbedContent, ProtoFile, Request, Response, Settings
 except:
     from octoprint_discordremote.genericforeversocket import GenericForeverSocket
-    from octoprint_discordremote.proto.messages_pb2 import Response, Settings, Request, EmbedContent, ProtoFile
+    from octoprint_discordremote.proto.messages_pb2 import (
+        EmbedContent,
+        ProtoFile,
+        Request,
+        Response,
+        Settings,
+    )
 
 channelid = 0
 

--- a/octoprint_discordremote/discordlink.py
+++ b/octoprint_discordremote/discordlink.py
@@ -2,9 +2,9 @@ import socket
 import threading
 from typing import Optional, Tuple
 
-from .genericforeversocket import GenericForeverSocket
 from . import Command
-from .proto.messages_pb2 import Response, Request, Settings
+from .genericforeversocket import GenericForeverSocket
+from .proto.messages_pb2 import Request, Response, Settings
 
 
 class DiscordLink:

--- a/octoprint_discordremote/genericforeversocket.py
+++ b/octoprint_discordremote/genericforeversocket.py
@@ -3,7 +3,7 @@ import socket
 import sys
 import threading
 import time
-from typing import List, Tuple, Callable, Optional
+from typing import Callable, List, Optional, Tuple
 
 if sys.platform == "linux" or sys.platform == "linux2":
     RECV_OPTS = socket.MSG_PEEK + socket.MSG_DONTWAIT

--- a/octoprint_discordremote/static/js/discordremote.js
+++ b/octoprint_discordremote/static/js/discordremote.js
@@ -8,9 +8,9 @@ $(function() {
     function DiscordRemoteViewModel(parameters) {
         var self = this;
 
-        // assign the injected parameters, e.g.:
-        // self.loginStateViewModel = parameters[0];
-        // self.settingsViewModel = parameters[1];
+        self.loginState = parameters[0];
+        self.access = parameters[1];
+
         self.isConnected = ko.observable(undefined);
         self.discordremote = $("#discordremote_indicator")
 
@@ -50,7 +50,7 @@ $(function() {
         DiscordRemoteViewModel,
 
         // e.g. loginStateViewModel, settingsViewModel, ...
-        [ "loginStateViewModel", "settingsViewModel" ],
+        [ "loginStateViewModel", "accessViewModel" ],
 
         // e.g. #settings_plugin_discordremote, #tab_plugin_octorant, ...
         [ "#navbar_plugin_discordremote" ]

--- a/octoprint_discordremote/templates/discordremote_navbar.jinja2
+++ b/octoprint_discordremote/templates/discordremote_navbar.jinja2
@@ -1,3 +1,3 @@
-<a id="discordremote_indicator" class="pull-right" title="DiscordRemote command" href="#" data-bind="click: function() { $root.sendTestMessage(); }">
+<a id="discordremote_indicator" class="pull-right" title="DiscordRemote command" href="#" data-bind="click: sendTestMessage, visible: loginState.hasPermissionKo(access.permissions.PLUGIN_DISCORDREMOTE_EXECUTE)">
     <i class="fa fa-gamepad"></i>
 </a>

--- a/octoprint_discordremote/templates/discordremote_settings.jinja2
+++ b/octoprint_discordremote/templates/discordremote_settings.jinja2
@@ -280,9 +280,9 @@
             <div style="clear:both">
                 <p>
                     {{ _("Here you can specify a file to be executed <strong>before</strong> and <strong>after</strong> each
-                    message is sent to Discord.") }}
+                    message is sent to Discord.") | safe }}
                     {{ _("<strong>The file should be executable by the user under which OctoPrint is running</strong>")
-                    }}
+                    | safe }}
                 </p>
             </div>
         </div>

--- a/unittests/mockdiscordtestcase.py
+++ b/unittests/mockdiscordtestcase.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import socket
-from random import randint
 from typing import Optional
 from unittest import TestCase
 from unittest.mock import Mock

--- a/unittests/mockdiscordtestcase.py
+++ b/unittests/mockdiscordtestcase.py
@@ -7,8 +7,8 @@ from unittest.mock import Mock
 
 from discord.embeds import Embed
 
-from octoprint_discordremote import DiscordLink, Command
-from octoprint_discordremote.proto.messages_pb2 import Response, ProtoFile
+from octoprint_discordremote import Command, DiscordLink
+from octoprint_discordremote.proto.messages_pb2 import ProtoFile, Response
 
 
 class TestLogger(logging.Logger):

--- a/unittests/test_command.py
+++ b/unittests/test_command.py
@@ -1,12 +1,8 @@
-import io
-from typing import List, Tuple, Optional
 
 import humanfriendly
 import mock
 import os
 
-from discord import Embed, File
-from zipfile import ZipFile
 
 from octoprint.printer import InvalidFileType, InvalidFileLocation
 

--- a/unittests/test_command.py
+++ b/unittests/test_command.py
@@ -1,13 +1,16 @@
 
-import humanfriendly
-import mock
 import os
 
+import humanfriendly
+import mock
+from octoprint.printer import InvalidFileLocation, InvalidFileType
 
-from octoprint.printer import InvalidFileType, InvalidFileLocation
-
-from octoprint_discordremote import Command, DiscordRemotePlugin, Response, ProtoFile
-from octoprint_discordremote.responsebuilder import COLOR_INFO, COLOR_ERROR, COLOR_SUCCESS
+from octoprint_discordremote import Command, DiscordRemotePlugin, ProtoFile, Response
+from octoprint_discordremote.responsebuilder import (
+    COLOR_ERROR,
+    COLOR_INFO,
+    COLOR_SUCCESS,
+)
 from unittests.mockdiscordtestcase import MockDiscordTestCase
 
 file_list = {'local': {

--- a/unittests/test_discordlink.py
+++ b/unittests/test_discordlink.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-
 from octoprint_discordremote import EmbedContent, Response
 from unittests.mockdiscordtestcase import MockDiscordTestCase
 

--- a/unittests/test_discordlink.py
+++ b/unittests/test_discordlink.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals
 
-import time
 
 from octoprint_discordremote import EmbedContent, Response
 from unittests.mockdiscordtestcase import MockDiscordTestCase

--- a/unittests/test_plugin.py
+++ b/unittests/test_plugin.py
@@ -1,12 +1,8 @@
-import os
-import time
 from base64 import b64encode
 from unittest import skipIf
-from unittest.mock import Mock
 
 import mock
 import octoprint
-import yaml
 
 from octoprint_discordremote import DiscordRemotePlugin
 from unittests.mockdiscordtestcase import MockDiscordTestCase

--- a/unittests/test_responsebuilder.py
+++ b/unittests/test_responsebuilder.py
@@ -1,5 +1,11 @@
-from octoprint_discordremote.responsebuilder import success_embed, COLOR_SUCCESS, error_embed, COLOR_ERROR, info_embed, \
-    COLOR_INFO
+from octoprint_discordremote.responsebuilder import (
+    COLOR_ERROR,
+    COLOR_INFO,
+    COLOR_SUCCESS,
+    error_embed,
+    info_embed,
+    success_embed,
+)
 from unittests.mockdiscordtestcase import MockDiscordTestCase
 
 

--- a/unittests/test_system_commands.py
+++ b/unittests/test_system_commands.py
@@ -1,9 +1,10 @@
 import json
 from collections import OrderedDict
+
 from mock import mock
 
 from octoprint_discordremote.command_plugins.system_commands import SystemCommands
-from octoprint_discordremote.responsebuilder import COLOR_SUCCESS, COLOR_ERROR
+from octoprint_discordremote.responsebuilder import COLOR_ERROR, COLOR_SUCCESS
 from unittests.mockdiscordtestcase import MockDiscordTestCase
 
 


### PR DESCRIPTION
Hi, I'm an active contributor to OctoPrint core. I helped ship [OctoPrint 2.0.0rc1](https://github.com/OctoPrint/OctoPrint/releases/tag/2.0.0rc1) and I'm now helping plugins stay compatible with the new and upcoming OctoPrint releases, which is why you're receiving this PR.

# What this PR does

The main goal of this PR is to fix multiple compatibility issues and usages of long-deprecated features that would cause the plugin installation to fail on OctoPrint 2.0.0rc1.

In particular:
- Replace `user_permission`, which has been removed in OctoPrint 2.0.0, with proper custom permissions, as suggested by the "Migrating to 2.0.0" guide ([ref](https://docs.octoprint.org/en/dev/plugins/migration_2_0_0.html#removed-octoprint-server-admin-permission-octoprint-server-user-permission)).
- Implement `is_api_protected` ([ref](https://docs.octoprint.org/en/dev/plugins/mixins.html#octoprint.plugin.SimpleApiPlugin.is_api_protected)).
- Implement `TemplatePlugin` autoescape ([ref](https://docs.octoprint.org/en/main/plugins/mixins.html#octoprint.plugin.TemplatePlugin.is_template_autoescaped)).

Minor improvements are also applied like removal of unused imports, sorting imports using Ruff's `isort`, etc.

## Review suggestions

Each change is isolated in its own commit, so I suggest reviewing this PR commit-by-commit rather than as a single diff. If merged, I'd also suggest keeping the commits separate so individual changes can be reverted if any of them turn out to be problematic.

## Testing

I tested the installation on both OctoPrint 2.0.0rc1 and the latest stable release 1.11.7, and everything appears to work correctly.

Specifically, the plugin's navbar button is now correctly hidden from those without the required privileges (e.g., users in the read-only group). The plugin applies the default button permission to all users in the User and Admins groups, so common users shouldn't notice any difference/breaking change when updating the plugin.